### PR TITLE
feat: add automatic language detection and switch prompt

### DIFF
--- a/docs/index-zh.html
+++ b/docs/index-zh.html
@@ -207,10 +207,117 @@
         a:hover {
             text-decoration: underline;
         }
+
+        /* Language notification banner */
+        .language-notification {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 12px 20px;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            gap: 20px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+            z-index: 1000;
+            animation: slideDown 0.3s ease-out;
+        }
+
+        @keyframes slideDown {
+            from {
+                transform: translateY(-100%);
+            }
+
+            to {
+                transform: translateY(0);
+            }
+        }
+
+        .language-notification.show {
+            display: flex;
+        }
+
+        .language-notification-content {
+            display: flex;
+            align-items: center;
+            gap: 15px;
+            flex-wrap: wrap;
+        }
+
+        .language-notification-text {
+            font-size: 14px;
+        }
+
+        .language-notification-buttons {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+        }
+
+        .language-notification-btn {
+            padding: 6px 16px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 14px;
+            font-weight: 500;
+            transition: all 0.2s;
+        }
+
+        .language-notification-btn.primary {
+            background: white;
+            color: #667eea;
+        }
+
+        .language-notification-btn.primary:hover {
+            background: #f0f0f0;
+        }
+
+        .language-notification-btn.secondary {
+            background: rgba(255, 255, 255, 0.2);
+            color: white;
+        }
+
+        .language-notification-btn.secondary:hover {
+            background: rgba(255, 255, 255, 0.3);
+        }
+
+        .language-notification-close {
+            background: none;
+            border: none;
+            color: white;
+            font-size: 20px;
+            cursor: pointer;
+            padding: 0 5px;
+            margin-left: 10px;
+            opacity: 0.8;
+        }
+
+        .language-notification-close:hover {
+            opacity: 1;
+        }
     </style>
 </head>
 
 <body>
+    <!-- Language notification banner -->
+    <div id="language-notification" class="language-notification">
+        <div class="language-notification-content">
+            <span class="language-notification-text">
+                🌏 Your browser language is set to English. Switch to English version?
+            </span>
+            <div class="language-notification-buttons">
+                <button class="language-notification-btn primary" onclick="switchLanguage()">Switch to English</button>
+                <button class="language-notification-btn secondary" onclick="dismissNotification(true)">Don't show
+                    again</button>
+            </div>
+        </div>
+        <button class="language-notification-close" onclick="dismissNotification(false)">×</button>
+    </div>
+
     <div class="language-switcher">
         <a href="index-zh.html" class="active">中文</a> | <a href="index.html">English</a>
     </div>
@@ -305,6 +412,45 @@
     </div>
 
     <script>
+        // Language detection and notification
+        function checkLanguagePreference() {
+            // Check if user has dismissed the notification
+            const dismissed = localStorage.getItem('language-notification-dismissed');
+            if (dismissed === 'true') {
+                return;
+            }
+
+            // Detect browser language
+            const browserLang = navigator.language || navigator.userLanguage;
+            const isChinese = browserLang.startsWith('zh');
+
+            // Show notification if browser is NOT set to Chinese
+            if (!isChinese) {
+                const notification = document.getElementById('language-notification');
+                if (notification) {
+                    notification.classList.add('show');
+                }
+            }
+        }
+
+        function switchLanguage() {
+            window.location.href = 'index.html';
+        }
+
+        function dismissNotification(permanent) {
+            const notification = document.getElementById('language-notification');
+            if (notification) {
+                notification.classList.remove('show');
+            }
+
+            if (permanent) {
+                localStorage.setItem('language-notification-dismissed', 'true');
+            }
+        }
+
+        // Check language preference on page load
+        document.addEventListener('DOMContentLoaded', checkLanguagePreference);
+
         // Fetch manifest.json version from GitHub to display latest code version
         async function fetchManifestVersion() {
             try {

--- a/docs/index.html
+++ b/docs/index.html
@@ -207,10 +207,116 @@
         a:hover {
             text-decoration: underline;
         }
+
+        /* Language notification banner */
+        .language-notification {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 12px 20px;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            gap: 20px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+            z-index: 1000;
+            animation: slideDown 0.3s ease-out;
+        }
+
+        @keyframes slideDown {
+            from {
+                transform: translateY(-100%);
+            }
+
+            to {
+                transform: translateY(0);
+            }
+        }
+
+        .language-notification.show {
+            display: flex;
+        }
+
+        .language-notification-content {
+            display: flex;
+            align-items: center;
+            gap: 15px;
+            flex-wrap: wrap;
+        }
+
+        .language-notification-text {
+            font-size: 14px;
+        }
+
+        .language-notification-buttons {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+        }
+
+        .language-notification-btn {
+            padding: 6px 16px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 14px;
+            font-weight: 500;
+            transition: all 0.2s;
+        }
+
+        .language-notification-btn.primary {
+            background: white;
+            color: #667eea;
+        }
+
+        .language-notification-btn.primary:hover {
+            background: #f0f0f0;
+        }
+
+        .language-notification-btn.secondary {
+            background: rgba(255, 255, 255, 0.2);
+            color: white;
+        }
+
+        .language-notification-btn.secondary:hover {
+            background: rgba(255, 255, 255, 0.3);
+        }
+
+        .language-notification-close {
+            background: none;
+            border: none;
+            color: white;
+            font-size: 20px;
+            cursor: pointer;
+            padding: 0 5px;
+            margin-left: 10px;
+            opacity: 0.8;
+        }
+
+        .language-notification-close:hover {
+            opacity: 1;
+        }
     </style>
 </head>
 
 <body>
+    <!-- Language notification banner -->
+    <div id="language-notification" class="language-notification">
+        <div class="language-notification-content">
+            <span class="language-notification-text">
+                🌏 您的浏览器语言设置为中文。是否切换到中文版本？
+            </span>
+            <div class="language-notification-buttons">
+                <button class="language-notification-btn primary" onclick="switchLanguage()">切换到中文</button>
+                <button class="language-notification-btn secondary" onclick="dismissNotification(true)">不再显示</button>
+            </div>
+        </div>
+        <button class="language-notification-close" onclick="dismissNotification(false)">×</button>
+    </div>
+
     <div class="language-switcher">
         <a href="index-zh.html">中文</a> | <a href="index.html" class="active">English</a>
     </div>
@@ -307,6 +413,45 @@
     </div>
 
     <script>
+        // Language detection and notification
+        function checkLanguagePreference() {
+            // Check if user has dismissed the notification
+            const dismissed = localStorage.getItem('language-notification-dismissed');
+            if (dismissed === 'true') {
+                return;
+            }
+
+            // Detect browser language
+            const browserLang = navigator.language || navigator.userLanguage;
+            const isChinese = browserLang.startsWith('zh');
+
+            // Show notification if browser is set to Chinese
+            if (isChinese) {
+                const notification = document.getElementById('language-notification');
+                if (notification) {
+                    notification.classList.add('show');
+                }
+            }
+        }
+
+        function switchLanguage() {
+            window.location.href = 'index-zh.html';
+        }
+
+        function dismissNotification(permanent) {
+            const notification = document.getElementById('language-notification');
+            if (notification) {
+                notification.classList.remove('show');
+            }
+
+            if (permanent) {
+                localStorage.setItem('language-notification-dismissed', 'true');
+            }
+        }
+
+        // Check language preference on page load
+        document.addEventListener('DOMContentLoaded', checkLanguagePreference);
+
         // Fetch manifest.json version from GitHub to display latest code version
         async function fetchManifestVersion() {
             try {


### PR DESCRIPTION
- Detect browser language using navigator.language
- Show notification banner when language mismatch detected
- Allow users to switch language with one click
- Remember user preference with localStorage
- Add 'Don't show again' option
- Apply to both English and Chinese index pages
- Styled banner with gradient background and animations