### PR TITLE
docs: add disclaimer pages

### DIFF
--- a/docs/disclaimer-zh.html
+++ b/docs/disclaimer-zh.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>免责声明 - YouTube双语字幕翻译助手</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Microsoft YaHei', sans-serif;
+            line-height: 1.6;
+            color: #333;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            padding: 40px 20px;
+        }
+
+        .language-switcher {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            background: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+            z-index: 1000;
+        }
+
+        .language-switcher a {
+            color: #667eea;
+            text-decoration: none;
+            font-weight: 500;
+            padding: 4px 8px;
+        }
+
+        .language-switcher a:hover {
+            text-decoration: underline;
+        }
+
+        .language-switcher .active {
+            color: #374151;
+            font-weight: 600;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            padding: 40px;
+            border-radius: 16px;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+        }
+
+        .back-link {
+            display: inline-block;
+            color: #667eea;
+            text-decoration: none;
+            margin-bottom: 20px;
+            font-weight: 500;
+        }
+
+        .back-link:hover {
+            text-decoration: underline;
+        }
+
+        h1 {
+            color: #667eea;
+            margin-bottom: 30px;
+            font-size: 32px;
+        }
+
+        h2 {
+            color: #374151;
+            margin-top: 30px;
+            margin-bottom: 15px;
+            font-size: 24px;
+        }
+
+        p {
+            margin-bottom: 15px;
+            color: #4b5563;
+        }
+
+        ul {
+            margin-left: 20px;
+            margin-bottom: 15px;
+        }
+
+        li {
+            margin-bottom: 10px;
+            color: #4b5563;
+        }
+
+        .highlight {
+            background: #fef3c7;
+            padding: 20px;
+            border-left: 4px solid #f59e0b;
+            border-radius: 4px;
+            margin: 20px 0;
+        }
+
+        .highlight p {
+            margin-bottom: 0;
+        }
+
+        strong {
+            color: #1f2937;
+        }
+
+        .last-updated {
+            margin-top: 40px;
+            padding-top: 20px;
+            border-top: 1px solid #e5e7eb;
+            color: #6b7280;
+            font-size: 14px;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="language-switcher">
+        <a href="disclaimer.html">English</a> | <a href="disclaimer-zh.html" class="active">中文</a>
+    </div>
+
+    <div class="container">
+        <a href="index-zh.html" class="back-link">← 返回首页</a>
+
+        <h1>⚠️ 免责声明</h1>
+
+        <div class="highlight">
+            <p><strong>重要提示：</strong>本浏览器扩展按"原样"提供，不提供任何形式的保证。使用本扩展前，请仔细阅读本免责声明。</p>
+        </div>
+
+        <h2>1. 无担保声明</h2>
+        <p>本扩展不提供任何明示或暗示的担保，包括但不限于：</p>
+        <ul>
+            <li>适销性保证</li>
+            <li>特定用途适用性保证</li>
+            <li>不侵权保证</li>
+            <li>翻译准确性或完整性保证</li>
+        </ul>
+
+        <h2>2. 第三方AI服务</h2>
+        <p>本扩展使用第三方AI服务（如OpenAI、Google Gemini、Anthropic Claude等）进行翻译。请注意：</p>
+        <ul>
+            <li><strong>API密钥：</strong>您必须提供自己从AI服务提供商处获取的API密钥</li>
+            <li><strong>费用：</strong>API使用可能会根据您的服务提供商定价产生费用。您需自行承担所有费用</li>
+            <li><strong>数据隐私：</strong>您的字幕文本将被发送到AI服务提供商进行翻译。请查阅他们的隐私政策</li>
+            <li><strong>服务可用性：</strong>翻译功能依赖于第三方服务的可用性</li>
+        </ul>
+
+        <h2>3. 翻译准确性</h2>
+        <p>AI生成的翻译可能包含错误、不准确或不当内容。本扩展：</p>
+        <ul>
+            <li>不保证翻译的准确性</li>
+            <li>不对误译或误解承担责任</li>
+            <li>不应用于关键、法律或医疗信息的翻译</li>
+        </ul>
+
+        <h2>4. YouTube服务条款</h2>
+        <p>本扩展通过添加翻译字幕来修改YouTube观看体验。用户需要：</p>
+        <ul>
+            <li>遵守YouTube的服务条款</li>
+            <li>确保使用本扩展不违反任何适用的法律法规</li>
+            <li>理解YouTube可能会更新其平台，从而影响本扩展的功能</li>
+        </ul>
+
+        <h2>5. 责任限制</h2>
+        <p>本扩展的开发者不对以下情况承担责任：</p>
+        <ul>
+            <li>任何直接、间接、附带、特殊或后果性损害</li>
+            <li>数据、利润或商业机会的损失</li>
+            <li>API使用产生的费用</li>
+            <li>因使用或无法使用本扩展而产生的任何问题</li>
+        </ul>
+
+        <h2>6. 用户责任</h2>
+        <p>使用本扩展即表示您确认：</p>
+        <ul>
+            <li>您负责管理自己的API密钥和相关费用</li>
+            <li>您理解AI生成翻译的局限性</li>
+            <li>您将遵守所有适用法律和服务条款使用本扩展</li>
+            <li>您接受使用本扩展的所有相关风险</li>
+        </ul>
+
+        <h2>7. 免责声明的变更</h2>
+        <p>本免责声明可能会不时更新。在变更后继续使用本扩展即表示接受更新后的免责声明。</p>
+
+        <h2>8. 开源软件</h2>
+        <p>本扩展是开源软件。您可以根据许可条款查看源代码、贡献改进或派生项目。</p>
+
+        <div class="highlight">
+            <p><strong>安装和使用本扩展即表示您已阅读、理解并同意本免责声明。</strong></p>
+        </div>
+
+        <div class="last-updated">
+            最后更新：2026年1月11日
+        </div>
+    </div>
+</body>
+
+</html>

--- a/docs/disclaimer.html
+++ b/docs/disclaimer.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Disclaimer - YouTube Bilingual Subtitle Translator</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            padding: 40px 20px;
+        }
+
+        .language-switcher {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            background: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+            z-index: 1000;
+        }
+
+        .language-switcher a {
+            color: #667eea;
+            text-decoration: none;
+            font-weight: 500;
+            padding: 4px 8px;
+        }
+
+        .language-switcher a:hover {
+            text-decoration: underline;
+        }
+
+        .language-switcher .active {
+            color: #374151;
+            font-weight: 600;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            padding: 40px;
+            border-radius: 16px;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+        }
+
+        .back-link {
+            display: inline-block;
+            color: #667eea;
+            text-decoration: none;
+            margin-bottom: 20px;
+            font-weight: 500;
+        }
+
+        .back-link:hover {
+            text-decoration: underline;
+        }
+
+        h1 {
+            color: #667eea;
+            margin-bottom: 30px;
+            font-size: 32px;
+        }
+
+        h2 {
+            color: #374151;
+            margin-top: 30px;
+            margin-bottom: 15px;
+            font-size: 24px;
+        }
+
+        p {
+            margin-bottom: 15px;
+            color: #4b5563;
+        }
+
+        ul {
+            margin-left: 20px;
+            margin-bottom: 15px;
+        }
+
+        li {
+            margin-bottom: 10px;
+            color: #4b5563;
+        }
+
+        .highlight {
+            background: #fef3c7;
+            padding: 20px;
+            border-left: 4px solid #f59e0b;
+            border-radius: 4px;
+            margin: 20px 0;
+        }
+
+        .highlight p {
+            margin-bottom: 0;
+        }
+
+        strong {
+            color: #1f2937;
+        }
+
+        .last-updated {
+            margin-top: 40px;
+            padding-top: 20px;
+            border-top: 1px solid #e5e7eb;
+            color: #6b7280;
+            font-size: 14px;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="language-switcher">
+        <a href="disclaimer.html" class="active">English</a> | <a href="disclaimer-zh.html">中文</a>
+    </div>
+
+    <div class="container">
+        <a href="index.html" class="back-link">← Back to Home</a>
+
+        <h1>⚠️ Disclaimer</h1>
+
+        <div class="highlight">
+            <p><strong>Important Notice:</strong> This browser extension is provided "as is" without warranty of any
+                kind. Please read this disclaimer carefully before using the extension.</p>
+        </div>
+
+        <h2>1. No Warranty</h2>
+        <p>This extension is provided without any express or implied warranties, including but not limited to:</p>
+        <ul>
+            <li>Warranties of merchantability</li>
+            <li>Fitness for a particular purpose</li>
+            <li>Non-infringement</li>
+            <li>Accuracy or completeness of translations</li>
+        </ul>
+
+        <h2>2. Third-Party AI Services</h2>
+        <p>This extension uses third-party AI services (such as OpenAI, Google Gemini, Anthropic Claude, etc.) for
+            translation. Please note:</p>
+        <ul>
+            <li><strong>API Keys:</strong> You must provide your own API key from your chosen AI service provider</li>
+            <li><strong>Costs:</strong> API usage may incur costs based on your provider's pricing. You are solely
+                responsible for any charges</li>
+            <li><strong>Data Privacy:</strong> Your subtitle text will be sent to the AI service provider for
+                translation. Please review their privacy policies</li>
+            <li><strong>Service Availability:</strong> Translation functionality depends on the availability of
+                third-party services</li>
+        </ul>
+
+        <h2>3. Translation Accuracy</h2>
+        <p>AI-generated translations may contain errors, inaccuracies, or inappropriate content. The extension:</p>
+        <ul>
+            <li>Does not guarantee the accuracy of translations</li>
+            <li>Cannot be held responsible for mistranslations or misunderstandings</li>
+            <li>Should not be relied upon for critical, legal, or medical information</li>
+        </ul>
+
+        <h2>4. YouTube Terms of Service</h2>
+        <p>This extension modifies the YouTube viewing experience by adding translated subtitles. Users are responsible
+            for:</p>
+        <ul>
+            <li>Complying with YouTube's Terms of Service</li>
+            <li>Ensuring their use of this extension does not violate any applicable laws or regulations</li>
+            <li>Understanding that YouTube may update their platform in ways that affect this extension's functionality
+            </li>
+        </ul>
+
+        <h2>5. Limitation of Liability</h2>
+        <p>The developers of this extension shall not be liable for:</p>
+        <ul>
+            <li>Any direct, indirect, incidental, special, or consequential damages</li>
+            <li>Loss of data, profits, or business opportunities</li>
+            <li>Costs incurred from API usage</li>
+            <li>Any issues arising from the use or inability to use this extension</li>
+        </ul>
+
+        <h2>6. User Responsibility</h2>
+        <p>By using this extension, you acknowledge that:</p>
+        <ul>
+            <li>You are responsible for managing your own API keys and associated costs</li>
+            <li>You understand the limitations of AI-generated translations</li>
+            <li>You will use the extension in compliance with all applicable laws and terms of service</li>
+            <li>You accept all risks associated with using this extension</li>
+        </ul>
+
+        <h2>7. Changes to This Disclaimer</h2>
+        <p>This disclaimer may be updated from time to time. Continued use of the extension after changes constitutes
+            acceptance of the updated disclaimer.</p>
+
+        <h2>8. Open Source</h2>
+        <p>This extension is open source software. You may review the source code, contribute improvements, or fork the
+            project according to the license terms.</p>
+
+        <div class="highlight">
+            <p><strong>By installing and using this extension, you acknowledge that you have read, understood, and agree
+                    to this disclaimer.</strong></p>
+        </div>
+
+        <div class="last-updated">
+            Last Updated: January 11, 2026
+        </div>
+    </div>
+</body>
+
+</html>

--- a/docs/index-zh.html
+++ b/docs/index-zh.html
@@ -378,6 +378,11 @@
                 <p>了解我们如何保护您的数据和隐私</p>
             </a>
 
+            <a href="disclaimer-zh.html" class="link-card">
+                <h2>⚠️ 免责声明</h2>
+                <p>重要法律信息和责任限制</p>
+            </a>
+
             <a href="changelog-zh.html" class="link-card">
                 <h2>📝 更新日志</h2>
                 <p>版本历史和发布说明</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -379,6 +379,11 @@
                 <p>Learn how we protect your data and privacy</p>
             </a>
 
+            <a href="disclaimer.html" class="link-card">
+                <h2>⚠️ Disclaimer</h2>
+                <p>Important legal information and limitations</p>
+            </a>
+
             <a href="changelog.html" class="link-card">
                 <h2>📝 Changelog</h2>
                 <p>Version history and release notes</p>


### PR DESCRIPTION
Added comprehensive disclaimer pages in English and Chinese:

New Files:
- docs/disclaimer.html - English disclaimer
- docs/disclaimer-zh.html - Chinese disclaimer

Content Covered:
- No warranty statement
- Third-party AI service usage and costs
- Translation accuracy limitations
- YouTube Terms of Service compliance
- Limitation of liability
- User responsibilities
- Open source information

Updated:
- docs/index.html - Added disclaimer link
- docs/index-zh.html - Added disclaimer link (免责声明)

This provides important legal protection and sets clear expectations for users regarding API costs, translation accuracy, and service limitations.