### PR TITLE
feat: include branch name, commit and version in build filename

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,11 +6,15 @@ VERSION=$(grep '"version"' manifest.json | sed 's/.*"version": "\(.*\)".*/\1/')
 # Get short git commit hash
 COMMIT_HASH=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
-# Output filename with version and commit hash
-OUTPUT_FILE="yt-subtitle-translator-v${VERSION}-${COMMIT_HASH}.zip"
+# Get current branch name (sanitize for filename)
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | sed 's/\//-/g' || echo "unknown")
+
+# Output filename with version, branch, and commit hash
+OUTPUT_FILE="yt-subtitle-translator-v${VERSION}-${BRANCH_NAME}-${COMMIT_HASH}.zip"
 
 echo "Building extension package..."
 echo "Version: $VERSION"
+echo "Branch: $BRANCH_NAME"
 echo "Commit: $COMMIT_HASH"
 echo "Output: $OUTPUT_FILE"
 


### PR DESCRIPTION
   feat: include branch name in build filename
    
    Enhanced build script to include branch name in package filename:
    - Old format: yt-subtitle-translator-v1.4.1-6cf423f.zip
    - New format: yt-subtitle-translator-v1.4.1-feature-build-script-6cf423f.zip
    
    Benefits:
    - Instantly identify which branch a build came from
    - Useful when testing multiple feature branches
    - Branch name sanitized (/ replaced with -) for valid filenames
    - Complete traceability: version + branch + commit
    
    Example output:
    - Version: 1.4.1
    - Branch: feature-build-script
    - Commit: 6cf423f
    - Output: yt-subtitle-translator-v1.4.1-feature-build-script-6cf423f.zip

    feat: include git commit hash in build filename
    
    Enhanced build script to generate more informative package names:
    - Old format: yt-subtitle-translator-v1.4.1.zip
    - New format: yt-subtitle-translator-v1.4.1-a1b2c3d.zip
    
    Benefits:
    - Easy to identify which commit a build came from
    - Helps with debugging and version tracking
    - Useful for testing different builds
    - Commit hash extracted using: git rev-parse --short HEAD
    
    Example output:
    - Version: 1.4.1
    - Commit: 96e8d65
    - Output: yt-subtitle-translator-v1.4.1-96e8d65.zip