### PR TITLE
chore: change default locale to English (v1.5.1)

### DIFF
--- a/docs/changelog-zh.html
+++ b/docs/changelog-zh.html
@@ -137,8 +137,21 @@
 
         <div class="version">
             <div class="version-header">
-                <span class="version-number">v1.5.0</span>
+                <span class="version-number">v1.5.1</span>
                 <span class="badge latest">最新版本</span>
+                <span class="version-date">2026年1月12日</span>
+            </div>
+
+            <h3>🔧 配置更改</h3>
+            <ul>
+                <li>🌐 <strong>默认语言：</strong> 将默认语言从中文（zh_CN）更改为英语（en），以服务更广泛的国际用户</li>
+                <li>📱 <strong>用户体验：</strong> 对于没有匹配语言的用户，扩展现在将默认使用英语界面</li>
+            </ul>
+        </div>
+
+        <div class="version">
+            <div class="version-header">
+                <span class="version-number">v1.5.0</span>
                 <span class="version-date">2026年1月12日</span>
             </div>
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -164,8 +164,23 @@
 
         <div class="version">
             <div class="version-header">
-                <span class="version-number">v1.5.0</span>
+                <span class="version-number">v1.5.1</span>
                 <span class="badge latest">Latest</span>
+                <span class="version-date">January 12, 2026</span>
+            </div>
+
+            <h3>🔧 Configuration Changes</h3>
+            <ul>
+                <li>🌐 <strong>Default Locale:</strong> Changed default locale from Chinese (zh_CN) to English (en) for
+                    broader international audience</li>
+                <li>📱 <strong>User Experience:</strong> Extension will now default to English UI for users without a
+                    matching locale</li>
+            </ul>
+        </div>
+
+        <div class="version">
+            <div class="version-header">
+                <span class="version-number">v1.5.0</span>
                 <span class="version-date">January 12, 2026</span>
             </div>
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "__MSG_extensionDescription__",
-  "default_locale": "zh_CN",
+  "default_locale": "en",
   "permissions": [
     "storage"
   ],


### PR DESCRIPTION
- Change default_locale from zh_CN to en for broader audience
- Bump version to 1.5.1
- Update changelog documentation (EN/ZH)